### PR TITLE
Fixes expanded view selection

### DIFF
--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -325,6 +325,7 @@ class _CalendarState extends State<Calendar> {
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
+        selectedMonthsDays = Utils.daysInMonth(selected);
         displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(selected));
       });
 


### PR DESCRIPTION
When using showDatePicker in the expanded state, the dates don't change so the calendar display doesn't render new dates.